### PR TITLE
🔗🏠 Fixes the Home link to work  locally and on github

### DIFF
--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -33,8 +33,11 @@
       </a>
       {% endif %}
 
-      {% comment %} Always show link to home page. {% endcomment %}
-      {% assign indexurl = include.pathLocale | append: "index/" | absolute_url %}
+      {% comment %} Always show link to home page.
+      For this to work on any language we need to set the permalink of the languages to be:
+      `lang`/index.html
+      {% endcomment %}
+      {% assign indexurl = include.pathLocale | absolute_url %}
       <a class="navbar-brand" href="{{ indexurl }}">{{ include.language.index }}</a>
 
     </div>


### PR DESCRIPTION
This fixes what's mentioned on carpentries-i18n/carpentry-theme#12 - however, it requires
changes on lesson headings as said on the issue.